### PR TITLE
added request_oauth_tokens_by_authorization_code method

### DIFF
--- a/bingads/authorization.py
+++ b/bingads/authorization.py
@@ -375,6 +375,26 @@ class OAuthWithAuthorizationCode(OAuthAuthorization):
         )
         return endpoint if self.state is None else endpoint + '&state=' + self.state
 
+    def request_oauth_tokens_by_authorization_code(self, code):
+        """ Retrieves OAuth access and refresh tokens from the Microsoft Account authorization service using the
+        authorization received through the OAuth Flow.
+
+        :param code: The authorization code.
+        :return: OAuth tokens
+        :rtype: OAuthTokens
+        """
+        self._oauth_tokens = _LiveComOAuthService.get_access_token(
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            redirect_uri=self.redirection_uri,
+            grant_type='authorization_code',
+            code=code,
+        )
+
+        if self.token_refreshed_callback is not None:
+            self.token_refreshed_callback(self.oauth_tokens)  # invoke the callback when token refreshed.
+        return self.oauth_tokens
+
     def request_oauth_tokens_by_response_uri(self, response_uri):
         """ Retrieves OAuth access and refresh tokens from the Microsoft Account authorization service.
 


### PR DESCRIPTION
In our system... we already have the authorization code available by we need to get the oauth tokens. So I've had to result to doing this:

![image](https://cloud.githubusercontent.com/assets/19521402/24117239/68eeb9c2-0d77-11e7-938d-724e6df53526.png)

This seems unnecessary, as the `request_oauth_tokens_by_response_uri` method just uses the response_uri to extract out the code from it. Why not add this extra method for when people already have the code available?