### PR TITLE
enable encoding for bulk object reader

### DIFF
--- a/bingads/v11/bulk/file_reader.py
+++ b/bingads/v11/bulk/file_reader.py
@@ -34,7 +34,7 @@ class BulkFileReader:
 
         self._is_for_full_download = result_file_type is ResultFileType.full_download
         self._entities_iterator = None
-        self._bulk_stream_reader = _BulkStreamReader(file_path=self.file_path, file_format=self.file_format)
+        self._bulk_stream_reader = _BulkStreamReader(file_path=self.file_path, file_format=self.file_format, encoding=self._encoding)
         self._bulk_stream_reader.__enter__()
 
     def __enter__(self):

--- a/bingads/v11/internal/bulk/object_reader.py
+++ b/bingads/v11/internal/bulk/object_reader.py
@@ -10,7 +10,7 @@ class _BulkObjectReader():
         self._delimiter = delimiter
         self._encoding = encoding
 
-        self._csv_reader = _CsvReader(self.file_path, delimiter=self.delimiter)
+        self._csv_reader = _CsvReader(self.file_path, delimiter=self.delimiter, encoding=self._encoding)
         self._csv_reader.__enter__()
         headers = self._read_headers()
         self._column_mapping = dict(zip(headers, range(0, len(headers))))

--- a/bingads/v11/internal/bulk/stream_reader.py
+++ b/bingads/v11/internal/bulk/stream_reader.py
@@ -17,7 +17,7 @@ class _BulkStreamReader():
 
         self._delimiter = ',' if self.file_format == DownloadFileType.csv else '\t'
         self._passed_first_row = False
-        self._bulk_object_reader = _BulkObjectReader(self.file_path, self.delimiter)
+        self._bulk_object_reader = _BulkObjectReader(self.file_path, self.delimiter, encoding = self._encoding)
         self._bulk_object_reader.__enter__()
         self._next_object = None
 


### PR DESCRIPTION
pass the encoding field to csv_reader when using BulkFileReader to parse the result entities, currently if the sys default encoding is not utf8, the entity parser will fail to parse the first element in the csv header(Type) because of the leading utf8 special chars "\xef\xbb\xbf"