### PR TITLE
Adjust requirements to use enum-compat in place of enum34

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ suds-jurko==0.6.0
 requests
 future
 six
-enum34
+enum-compat
 pytest
 mock
 parameterizedtestcase

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     'future',
     'six',
     'requests',
-    'enum34',
+    'enum-compat',
 ]
 
 setup(


### PR DESCRIPTION
When using enum34 issues can occur on any python version over 3.4. By using this package it will use the standard package on later versions of python. Using enum34 in later versions of python can cause issues with pip itself and break installs.