### PR TITLE
Open session via resource manager

### DIFF
--- a/bingads/v13/reporting/reporting_operation.py
+++ b/bingads/v13/reporting/reporting_operation.py
@@ -108,13 +108,13 @@ class ReportingDownloadOperation(object):
         headers = {
             'User-Agent': USER_AGENT,
         }
-        s = requests.Session()
-        s.mount('https://', TlsHttpAdapter())
-        timeout_seconds = None if timeout_in_milliseconds is None else timeout_in_milliseconds / 1000.0
-        try:
-            r = s.get(url, headers=headers, stream=True, verify=True, timeout=timeout_seconds)
-        except requests.Timeout as ex:
-            raise FileDownloadException(ex)
+        with requests.Session() as s:
+            s.mount('https://', TlsHttpAdapter())
+            timeout_seconds = None if timeout_in_milliseconds is None else timeout_in_milliseconds / 1000.0
+            try:
+                r = s.get(url, headers=headers, stream=True, verify=True, timeout=timeout_seconds)
+            except requests.Timeout as ex:
+                raise FileDownloadException(ex)
         r.raise_for_status()
         try:
             with open(zip_file_path, 'wb') as f:


### PR DESCRIPTION
The socket used to start a session was not closed at the end of the execution, leading to rather unpleasant warnings about unclosed sockets:

`ResourceWarning: unclosed <socket.socket fd=1844, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('10.10.80.67', 55635), raddr=('40.116.232.96', 443)>
  overwrite=True`

Changed the way a `Session` is used via a resource manager.