### PR TITLE
auth_helper: Add option to specify client_secret

### DIFF
--- a/examples/v13/auth_helper.py
+++ b/examples/v13/auth_helper.py
@@ -17,6 +17,7 @@ ENVIRONMENT='sandbox' # If you use 'production' then you must also update the DE
 # The REFRESH_TOKEN should always be in a secure location.
 CLIENT_ID='db41b09d-6e50-4f4a-90ac-5a99caefb52f'
 CLIENT_STATE='ClientStateGoesHere'
+CLIENT_SECRET="ClientSecretGoesHere"
 REFRESH_TOKEN="refresh.txt"
 
 ALL_CAMPAIGN_TYPES=['Audience DynamicSearchAds Search Shopping']
@@ -61,6 +62,7 @@ def authenticate_with_oauth(authorization_data):
         client_id=CLIENT_ID,
         env=ENVIRONMENT
     )
+    authentication.client_secret=CLIENT_SECRET
 
     # It is recommended that you specify a non guessable 'state' request parameter to help prevent
     # cross site request forgery (CSRF). 


### PR DESCRIPTION
Solves issue #158.

Without this adaption, I wasn't able to connect to the API in the
"production" environment. I also wasn't able to find a constructor
argument to set this secret.

Of course, connection to the production env also requires setting the
following variables to correct values:

    auth_helper.CLIENT_ID,
    auth_helper.CLIENT_SECRET,
    auth_helper.DEVELOPER_TOKEN,
    auth_helper.ENVIRONMENT.

It also requires putting one's refresh token into the file specified by

    auth_helper.REFRESH_TOKEN.

After adapting these to my specific use case and implementing the small change in the `auth_helper` module, the example code worked like a charm! :)