### PR TITLE
Removed parameter IncludeLinkedAccountIds from GetUser call

### DIFF
--- a/examples/v13/customer_signup.py
+++ b/examples/v13/customer_signup.py
@@ -8,8 +8,7 @@ def main(authorization_data):
     try:
         output_status_message("-----\nGetUser:")
         get_user_response=customer_service.GetUser(
-            UserId=None,
-            IncludeLinkedAccountIds=True
+            UserId=None
         )
         user = get_user_response.User
         customer_roles=get_user_response.CustomerRoles

--- a/examples/v13/invite_user.py
+++ b/examples/v13/invite_user.py
@@ -101,8 +101,7 @@ def main(authorization_data):
         for info in users_info['UserInfo']:            
             output_status_message("-----\nGetUser:")
             get_user_response=customer_service.GetUser(
-                UserId=info.Id,
-                IncludeLinkedAccountIds=True)
+                UserId=info.Id)
             user = get_user_response.User
             customer_roles=get_user_response.CustomerRoles
             output_status_message("User:")


### PR DESCRIPTION
When running the example "customer_signup.py" the following error is thrown: 

```
Loading the web service client proxies...
-----
GetUser:
GetUser() got an unexpected keyword argument 'IncludeLinkedAccountIds'
```

This is because an update introduced on V13, it is already corrected on the online documentation but not in the SDK sample.
https://github.com/MicrosoftDocs/Advertising-docs/issues/629
@eric-urban 