### PR TITLE
Update setup.py to include long description type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,26 +11,20 @@ with the Python programming language.
 The SDK includes proxy classes for all Bing Ads API web services and abstracts the low level details of authentication with OAuth.
 You can also read and write bulk files with the SDK BulkFileReader and BulkFileWriter,
 and use the high level BulkServiceManager interface to abstract and execute operations in the low level Bulk API.
-For more information, see `Bing Ads Client Libraries`_.
+For more information, see `Bing Ads Client Libraries <https://docs.microsoft.com/en-us/esrp-release-test/guides/client-libraries>`_.
 
 Getting Started
 ---------------
 
 To get started developing Bing Ads applications with Python, 
-install the SDK and either start with the `examples`_ or follow one of the application walkthroughs.
-For more information, see `Getting Started Using Python with Bing Ads Services`_.
+install the SDK and either start with the `examples <https://github.com/esrp-release-test/esrp-release-test-Python-SDK/tree/master/examples>`_ or follow one of the application walkthroughs.
+For more information, see `Getting Started Using Python with Bing Ads Services <https://docs.microsoft.com/en-us/esrp-release-test/guides/get-started-python>`_.
 
 External Dependencies
 ---------------------
 
-    - `suds-community`_
-    - `requests`_
-    - `enum34`_
-
-.. _Bing Ads Client Libraries: https://docs.microsoft.com/en-us/bingads/guides/client-libraries
-.. _examples: https://github.com/BingAds/BingAds-Python-SDK/tree/master/examples
-.. _Getting Started Using Python with Bing Ads Services: https://docs.microsoft.com/en-us/bingads/guides/get-started-python
-
-.. _suds-community: https://pypi.org/pypi/suds-community/
-.. _requests: http://pypi.python.org/pypi/requests
-.. _enum34: http://pypi.python.org/pypi/enum34
+    - `suds-community <https://pypi.org/pypi/suds-community>`_
+    
+    - `requests <http://pypi.python.org/pypi/requests>`_
+    
+    - `enum34 <http://pypi.python.org/pypi/enum34>`_

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     name='bingads',
     version=VERSION,
     description='A library to make working with the Bing Ads APIs and bulk services easy',
-    long_description=readme + '\n\n' + history,
+    long_description=readme,
     long_description_content_type ='text/x-rst',
     author='Bing Ads SDK Team',
     author_email='bing_ads_sdk@microsoft.com',

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     version=VERSION,
     description='A library to make working with the Bing Ads APIs and bulk services easy',
     long_description=readme + '\n\n' + history,
+    long_description_content_type ='text/x-rst',
     author='Bing Ads SDK Team',
     author_email='bing_ads_sdk@microsoft.com',
     url='https://github.com/BingAds/BingAds-Python-SDK',


### PR DESCRIPTION
Adding a new metadata field to specify the type of long description. This will enable rendering of description when publishing to PyPI