### PR TITLE
Remove pkg_resources (deprecated)

### DIFF
--- a/bingads/service_client.py
+++ b/bingads/service_client.py
@@ -304,14 +304,18 @@ class _ServiceCall:
         return self._name
 
 
-import pkg_resources
+import sys
+if sys.version_info >= (3, 9):
+    import importlib.resources as importlib_resources
+else:
+    import importlib_resources
 import types
 from suds.sudsobject import Property
 from suds.sax.text import Text
 
 # this is used to create entity only. Given the sandbox should have the same contract, we are good to use sandbox wsdl.
 _CAMPAIGN_MANAGEMENT_SERVICE_V13 = Client(
-    'file:///' + pkg_resources.resource_filename('bingads', 'v13/proxies/sandbox/campaignmanagement_service.xml'), cache=DictCache())
+    'file:///' + importlib_resources.files('bingads', 'v13/proxies/sandbox/campaignmanagement_service.xml'), cache=DictCache())
 _CAMPAIGN_OBJECT_FACTORY_V13 = _CAMPAIGN_MANAGEMENT_SERVICE_V13.factory
 _CAMPAIGN_OBJECT_FACTORY_V13.builder = BingAdsBuilder(_CAMPAIGN_OBJECT_FACTORY_V13.builder.resolver)
 

--- a/bingads/service_info.py
+++ b/bingads/service_info.py
@@ -1,11 +1,16 @@
-import pkg_resources
+import sys
+
+if sys.version_info >= (3, 9):
+    import importlib.resources as importlib_resources
+else:
+    import importlib_resources
 
 _SERVICE_LIST = ['adinsight', 'bulk', 'campaignmanagement', 'customerbilling', 'customermanagement', 'reporting']
 
 SERVICE_INFO_DICT_V13 = {}
 
 for service in _SERVICE_LIST:
-    SERVICE_INFO_DICT_V13[(service, 'production')] = 'file:///' + pkg_resources.resource_filename('bingads', 'v13/proxies/production/%s_service.xml' % (service))
-    SERVICE_INFO_DICT_V13[(service, 'sandbox')] = 'file:///' + pkg_resources.resource_filename('bingads', 'v13/proxies/sandbox/%s_service.xml' % (service))
+    SERVICE_INFO_DICT_V13[(service, 'production')] = 'file:///' + importlib_resources.files('bingads', 'v13/proxies/production/%s_service.xml' % (service))
+    SERVICE_INFO_DICT_V13[(service, 'sandbox')] = 'file:///' + importlib_resources.files('bingads', 'v13/proxies/sandbox/%s_service.xml' % (service))
 
 SERVICE_INFO_DICT = {13: SERVICE_INFO_DICT_V13}

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ requirements = [
     'suds-community>=1.1.0',
     'requests',
     'enum34;python_version<"3.9"',
+    'importlib_resources>=1.3;python_version<"3.9"'
 ]
 
 setup(


### PR DESCRIPTION
```
/usr/local/lib/python3.12/site-packages/bingads/service_info.py:1: UserWarning: pkg_resources is deprecated as an API. 
See https://setuptools.pypa.io/en/latest/pkg_resources.html. 
The pkg_resources package is slated for removal as early as 2025-11-30. 
Refrain from using this package or pin to Setuptools<81.
```